### PR TITLE
Add uses-annotation for MSL

### DIFF
--- a/LibRAS/package.mo
+++ b/LibRAS/package.mo
@@ -1,4 +1,5 @@
 within;
 package LibRAS
   extends Modelica.Icons.Library;
+  annotation(uses(Modelica(version="3.2.2")));
 end LibRAS;


### PR DESCRIPTION
Added a uses-annotation to document which version of MSL is being used
and giving a hint to tools that MSL should be loaded together with the
library.